### PR TITLE
Implement keybindings for all functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
     <div id="container">
       <div id="mainButtonsContainer">
         <div id="timeOfDayToggle">
+          <button id="recallButton">
+            <i class="fas fa-bell"></i>
+          </button>
           <button id="toggleTimeOfDayButton" class="restricted">
             <i class="fas fa-sun"></i>
           </button>
@@ -54,13 +57,45 @@
               Clocktower. The timer controls can be found at the bottom,
               allowing to you start, stop, reset, edit, and quick adjust the
               current time. You can mute all sounds with the "sound" icon. To
-              switch between dawn and dusk (discussion & nomination phases),
-              press the sun/moon icon. You can move to the next day by pressing
-              the calendar icon. Switching to dusk (nomination phase) will
-              automatically shorten the timer. The timer will also be shortened
-              when advancing the days (to account for less people as the game
-              progresses). Hope you enjoy!
+              recall the town immediately (stopping the timer) you can press
+              the bell icon. To switch between dawn and dusk (discussion &
+              nomination phases), press the sun/moon icon. You can move to the
+              next day by pressing the calendar icon. Switching to dusk
+              (nomination phase) will automatically shorten the timer. The
+              timer will also be shortened when advancing the days (to account
+              for fewer alive people as the game progresses). Hope you enjoy!
             </p>
+            <p>
+              You may also control this app using keyboard-shortcuts:
+            </p>
+            <dl>
+              <dt><span class="key">Space</span></dt>
+              <dd>Start or stop the timer</dd>
+              <dt><span class="key">Backspace</span></dt>
+              <dd>Reset the timer</dd>
+              <dt><span class="key">Z</span></dt>
+              <dd>Edit the timer</dd>
+              <dt>
+                <span class="key">Up</span>/<span class="key">Right</span>/<span class="key">+</span>,
+                <br>
+                <span class="key">Down</span>/<span class="key">Left</span>/<span class="key">-</span>
+              </dt>
+              <dd>Quick adjust the timer</dd>
+              <dt><span class="key">R</span></dt>
+              <dd>Immediate recall town</dd>
+              <dt><span class="key">N</span>/<span class="key">Enter</span></dt>
+              <dd>Move to next phase (dusk/next day's dawn)</dd>
+              <dt><span class="key">F1</span>, <span class="key">F2</span></dt>
+              <dd>Goto current day's dawn/dusk</dd>
+              <dt><span class="key">F4</span></dt>
+              <dd>Goto next day's dawn</dd>
+              <dt><span class="key">D</span></dt>
+              <dd>Toggle Mute</dd>
+              <dt><span class="key">F</span></dt>
+              <dd>Toggle Fullscreen</dd>
+              <dt><span class="key">Q</span></dt>
+              <dd>Toggle this dialogue</dd>
+            </dl>
             <p>-</p>
             <p class="disclaimer">
               Disclaimer: Clocktowertimer is an open source project and is not

--- a/script.js
+++ b/script.js
@@ -5,11 +5,10 @@ const resetButton = document.getElementById("resetButton");
 const incrementTimeButton = document.getElementById("incrementTime");
 const editTimeButton = document.getElementById("editTime");
 const decrementTimeButton = document.getElementById("decrementTime");
+const recallButton = document.getElementById("recallButton");
 const toggleTimeOfDayButton = document.getElementById("toggleTimeOfDayButton");
 const dayValue = document.getElementById("dayValue");
 const incrementDayButton = document.getElementById("incrementDay");
-const dawnButton = document.getElementById("dawnButton");
-const duskButton = document.getElementById("duskButton");
 const body = document.body;
 const muteButton = document.getElementById("muteButton");
 
@@ -28,6 +27,120 @@ let timeValues = {
 let stepSize = 15;
 let attentionPeriod = 15;
 let timeOfDayText = document.getElementById("timeOfDayText");
+let keybindings = {
+  startstop:  [' ', 'Spacebar'],
+  reset:      'Backspace',
+  timer:      'Z',
+  timeplus:   ['Up', 'ArrowUp', 'Right', 'ArrowRight', '+'],
+  timeminus:  ['Down', 'ArrowDown', 'Left', 'ArrowLeft', '-'],
+  recall:     'R',
+  nextphase:  ['N', 'Enter'],
+  morning:    'F1',
+  evening:    'F2',
+  night:      'F3',
+  nextday:    'F4',
+  toggleinfo: 'Q',
+  mute:       'D',
+  fullscreen: 'F',
+}
+
+function findKey(search, map) {
+  if (search.length == 1)
+    search = search.toUpperCase();
+  for (const key in map) {
+    if (typeof map[key] === 'string' && map[key] === search ||
+        typeof map[key] === 'object' && map[key].includes(search)) {
+        return key;
+    }
+  }
+  return null;
+}
+
+function parseKeydown(e) {
+  let action = findKey(e.key, keybindings);
+  switch (action) {
+    case 'startstop':
+      startStopTimer();
+      break;
+    case 'reset':
+      resetTimer()
+      break;
+    case 'timer':
+      editTimer();
+      break;
+    case 'timeplus':
+      incrementTimer();
+      break;
+    case 'timeminus':
+      decrementTimer();
+      break;
+    case 'recall':
+      recall();
+      break;
+    case 'nextphase':
+      if (isDawn) {
+        toggleTimeOfDay();
+      } else {
+        incrementDay();
+      }
+      break;
+    case 'morning':
+      if(!isDawn) {
+        toggleTimeOfDay();
+      }
+      break;
+    case 'evening':
+      if(isDawn) {
+        toggleTimeOfDay();
+      }
+      break;
+    case 'night':
+      console.log('Night mode not yet implemented')
+      break;
+    case 'nextday':
+      incrementDay();
+      break;
+    case 'toggleinfo':
+      const dialogueBox = document.getElementById("dialogueBox");
+      if (dialogueBox.classList.contains("hidden")) {
+        showInfo();
+      } else {
+        exitInfo();
+      }
+      break;
+    case 'mute':
+      mute();
+      break;
+    case 'fullscreen':
+      if (document.fullscreenElement || /* Standard syntax */
+          document.webkitFullscreenElement || /* Safari and Opera syntax */
+          document.msFullscreenElement /* IE11 syntax */) {
+        if (document.exitFullscreen) {
+          document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) { /* Safari */
+          document.webkitExitFullscreen();
+        } else if (document.msExitFullscreen) { /* IE11 */
+          document.msExitFullscreen();
+        }
+      } else {
+        const elem = document.documentElement;
+        if (elem.requestFullscreen) {
+          elem.requestFullscreen();
+        } else if (elem.webkitRequestFullscreen) { /* Safari */
+          elem.webkitRequestFullscreen();
+        } else if (elem.msRequestFullscreen) { /* IE11 */
+          elem.msRequestFullscreen();
+        }
+      }
+      break;
+    default:
+      console.debug(`No Action for key: ${e.key} (${e.keyCode})`)
+  }
+  if(action != null) {
+    e.preventDefault();
+  }
+}
+document.addEventListener('keydown', parseKeydown);
 
 function applyConfig(config) {
   if (config.timeValues) {
@@ -129,7 +242,6 @@ function timer() {
       clearInterval(countdown);
       isTimerRunning = false;
       body.classList.remove("timerRunning");
-      startStopButton.textContent = "Restart";
       timeRemaining = defaultTime;
       playSound();
       return;
@@ -186,7 +298,7 @@ function updateDefaultTime() {
   }
 }
 
-startStopButton.addEventListener("click", () => {
+function startStopTimer() {
   if (!isTimerRunning) {
     timer();
     isTimerRunning = true;
@@ -198,24 +310,30 @@ startStopButton.addEventListener("click", () => {
     body.classList.remove("timerRunning");
     startStopButton.innerHTML = '<i class="fas fa-play"></i>';
   }
-});
+  startStopButton.blur();
+}
+startStopButton.addEventListener("click", startStopTimer);
 
-resetButton.addEventListener("click", () => {
+function resetTimer() {
   if (!isTimerRunning) {
     timeRemaining = defaultTime;
     displayTimeLeft(timeRemaining);
   }
-});
+  resetButton.blur();
+}
+resetButton.addEventListener("click", resetTimer);
 
-incrementTimeButton.addEventListener("click", () => {
+function incrementTimer() {
   if (!isTimerRunning) {
     defaultTime = Math.min(defaultTime + stepSize, 3599);
     timeRemaining = defaultTime;
     displayTimeLeft(timeRemaining);
   }
-});
+  incrementTimeButton.blur();
+}
+incrementTimeButton.addEventListener("click", incrementTimer);
 
-editTimeButton.addEventListener("click", () => {
+function editTimer() {
   if (!isTimerRunning) {
     const userTime = prompt(
       "New Time:\nPossible formats: 7.5, 7:30, 450s\nPossible range: 1 second - 59:99"
@@ -233,33 +351,24 @@ editTimeButton.addEventListener("click", () => {
       displayTimeLeft(timeRemaining);
     }
   }
-});
+  editTimeButton.blur();
+}
+editTimeButton.addEventListener("click", editTimer);
 
-document.getElementById("infoIcon").addEventListener("click", function () {
-  var dialogueBox = document.getElementById("dialogueBox");
-  dialogueBox.classList.remove("hidden");
-  dialogueBox.style.display = "block";
-});
-
-document.getElementById("closeButton").addEventListener("click", function () {
-  var dialogueBox = document.getElementById("dialogueBox");
-  dialogueBox.classList.add("hidden");
-  dialogueBox.style.display = "none";
-});
-
-decrementTimeButton.addEventListener("click", () => {
+function decrementTimer() {
   if (!isTimerRunning) {
     defaultTime = Math.max(defaultTime - stepSize, 0);
     timeRemaining = defaultTime;
     displayTimeLeft(timeRemaining);
   }
-});
+  decrementTimeButton.blur();
+}
+decrementTimeButton.addEventListener("click", decrementTimer);
 
-incrementDayButton.addEventListener("click", function () {
+function incrementDay() {
   if (!isTimerRunning) {
     currentDay += 1;
     dayValue.textContent = currentDay;
-
     isDawn = true;
     updateToggleButtonText();
     updateBackground();
@@ -267,9 +376,11 @@ incrementDayButton.addEventListener("click", function () {
     playDawnSound();
     updateSpanText();
   }
-});
+  incrementDayButton.blur();
+}
+incrementDayButton.addEventListener("click", incrementDay);
 
-muteButton.addEventListener("click", function () {
+function mute() {
   isMuted = !isMuted;
   const icon = muteButton.querySelector("i");
   if (isMuted) {
@@ -277,9 +388,21 @@ muteButton.addEventListener("click", function () {
   } else {
     icon.className = "fas fa-volume-up";
   }
-});
+  muteButton.blur();
+}
+muteButton.addEventListener("click", mute);
 
-toggleTimeOfDayButton.addEventListener("click", function () {
+
+function recall() {
+  if (isTimerRunning) {
+    startStopTimer()
+  }
+  playSound();
+  recallButton.blur();
+}
+recallButton.addEventListener("click", recall)
+
+function toggleTimeOfDay() {
   if (!isTimerRunning) {
     isDawn = !isDawn;
     updateToggleButtonText();
@@ -292,7 +415,24 @@ toggleTimeOfDayButton.addEventListener("click", function () {
       playDuskSound();
     }
   }
-});
+  toggleTimeOfDayButton.blur();
+}
+toggleTimeOfDayButton.addEventListener("click", toggleTimeOfDay );
+
+
+function showInfo() {
+  const dialogueBox = document.getElementById("dialogueBox");
+  dialogueBox.classList.remove("hidden");
+  dialogueBox.style.display = "block";
+}
+document.getElementById("infoIcon").addEventListener("click", showInfo);
+
+function exitInfo() {
+  const dialogueBox = document.getElementById("dialogueBox");
+  dialogueBox.classList.add("hidden");
+  dialogueBox.style.display = "none";
+}
+document.getElementById("closeButton").addEventListener("click", exitInfo);
 
 function updateToggleButtonText() {
   toggleTimeOfDayButton.innerHTML = isDawn

--- a/style.css
+++ b/style.css
@@ -45,10 +45,33 @@ body {
   display: none;
 }
 
-p {
+p, dl {
   font-size: 0.2em;
   color: rgb(61, 61, 61);
   text-align: left;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: max-content auto;
+  grid-row-gap: 2px;
+}
+
+dt {
+  grid-column-start: 1;
+}
+
+dt .key {
+  background-color: #000;
+  color: #fff;
+  padding: 1px 5px;
+  border-radius: 5px;
+  margin: 2px;
+  display: inline-block;
+}
+
+dd {
+  grid-column-start: 2;
 }
 
 .disclaimer {


### PR DESCRIPTION
You may now also control the timer using keyboard-shortcuts. Some of them (like Z, R, N, F, Q) are equivalent to the official app.

Space: Start or stop the timer
Backspace: Reset the timer
Z: Edit the timer
Up/Right/+, Down/Left/-: Quick adjust the timer
R: Immediate recall town
N/Enter: Move to next phase (dusk/next day's dawn)
F1, F2: Goto current day's dawn/dusk
F4: Goto next day's dawn
D: Toggle Mute
F: Toggle Fullscreen
Q: Toggle the information dialogue (not also listing the keybindings)

As a side effect I implemented an additional button to recall town: It plays the sound and stops the timer. Usefull to make announcments mid-day (and resume the timer afterwards) or to forcefully end a day (e.g. due to madness break).