### PR TITLE
Fix an edgecase in useSpotify()

### DIFF
--- a/spotify.js
+++ b/spotify.js
@@ -1,5 +1,5 @@
 function useSpotify() {
-  return Boolean(localStorage.getItem('spotify_access_token'));
+  return localStorage.getItem('spotify_access_token') && localStorage.getItem('spotify_access_token') !== 'undefined';
 }
 
 async function callSpotify(endpoint, method = 'PUT') {


### PR DESCRIPTION
If localStorage returns 'undefined' the old code evaluates to true and therefore would try to do (unauthorized) API calls.