### PR TITLE
Implement time travelling (prev. phase)

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,9 @@
               <dt><span class="key">R</span></dt>
               <dd>Immediate recall town</dd>
               <dt><span class="key">N</span>/<span class="key">Enter</span></dt>
-              <dd>Move to next phase (night/day/end of day/next day)</dd>
+              <dd>Move to next phase (night/day/end of day/night)</dd>
+              <dt><span class="key">P</span></dt>
+              <dd>Move back the previous phase (night/end of day/day/night)</dd>
               <dt>
                 <span class="key">F1</span>, <span class="key">F2</span>,
                 <span class="key">F3</span>

--- a/script.js
+++ b/script.js
@@ -37,6 +37,7 @@ let keybindings = {
   timeminus: ["Down", "ArrowDown", "Left", "ArrowLeft", "-"],
   recall: "R",
   nextphase: ["N", "Enter"],
+  previousphase: "P",
   day: "F1",
   endOfDay: "F2",
   night: "F3",
@@ -81,6 +82,14 @@ function parseKeydown(e) {
       recall();
       break;
     case "nextphase":
+      advanceTime();
+      break;
+    case "previousphase":
+      if (currentDay == 1 && isNight()) break;
+      if (!isEndOfDay()) {
+        currentDay = currentDay - 1;
+      }
+      phase++;
       advanceTime();
       break;
     case "toggleinfo":


### PR DESCRIPTION
This enables to shift back to the previous phase. Currently only available with the *P* shortcut, as this case most likely will be used upon accidential advancing through shortcuts.. This could also be usefull if one has to put town back to sleep (eg forgot to wake someone during night).


Thought on this? It's not the cleanest code.. I could also duplicate a lot if the Code from advanceTime() instead.