### PR TITLE
add math to determine array used for timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
     <div id="container">
       <div id="mainButtonsContainer">
         <div id="informationContainer">
+          <button id="updateButton">Enter Player Count</button>
+
           <button id="muteButton">
             <i class="fas fa-volume-up"></i>
           </button>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,56 @@ const dayValue = document.getElementById("dayValue");
 const body = document.body;
 const muteButton = document.getElementById("muteButton");
 
+let startingPlayerCount = parseInt(
+  prompt("Please enter a number between 5 and 15:")
+);
+const dayTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
+const dayStartValue = startingPlayerCount * 0.6 + 3;
+const dayEndValue = 3;
+const nightTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
+const nightStartValue = 4;
+const nightEndValue = 1;
+
+function roundToNearestQuarter(n) {
+  return Math.round(n * 4) / 4;
+}
+
+function generateExponentialDecay(startValue, endValue, totalNumbers) {
+  let values = [];
+  let b = -Math.log(endValue / startValue);
+  let step = 1 / (totalNumbers - 1);
+
+  for (let i = 0; i < totalNumbers; i++) {
+    let x = i * step;
+    let y = startValue * Math.exp(-b * x);
+    if (y < endValue) {
+      y = endValue;
+    }
+    values.push(roundToNearestQuarter(y));
+  }
+
+  return values;
+}
+
+let dayDecayValues = generateExponentialDecay(
+  dayStartValue,
+  dayEndValue,
+  dayTotalNumbers
+);
+
+let nightDecayValues = generateExponentialDecay(
+  nightStartValue,
+  nightEndValue,
+  nightTotalNumbers
+);
+
+function convertToSeconds(values) {
+  return values.map((value) => value * 60);
+}
+
+const dayDecayValuesSeconds = convertToSeconds(dayDecayValues);
+const nightDecayValuesSeconds = convertToSeconds(nightDecayValues);
+
 // State variables
 let isMuted = false;
 let countdown;
@@ -23,8 +73,8 @@ const DAY = 0,
   ENDOFDAY = 1,
   NIGHT = 2;
 let timeValues = {
-  day: [600, 480, 420, 420, 360, 360, 300, 300, 240, 180],
-  endOfDay: [180, 150, 150, 135, 135, 120, 120, 90, 75, 60],
+  day: dayDecayValuesSeconds,
+  endOfDay: nightDecayValuesSeconds,
 };
 let stepSize = 15;
 let volume = [50, 30, 80];

--- a/script.js
+++ b/script.js
@@ -10,56 +10,76 @@ const toggleTimeOfDayButton = document.getElementById("toggleTimeOfDayButton");
 const dayValue = document.getElementById("dayValue");
 const body = document.body;
 const muteButton = document.getElementById("muteButton");
+let timeValues = {}; // Initialize `timeValues` at a higher scope
 
-let startingPlayerCount = parseInt(
-  prompt("Please enter a number between 5 and 15:")
-);
-const dayTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
-const dayStartValue = startingPlayerCount * 0.6 + 3;
-const dayEndValue = 3;
-const nightTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
-const nightStartValue = 4;
-const nightEndValue = 1;
+function updateTimeValues(playerCount) {
+  const startingPlayerCount = playerCount;
+  const dayTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
+  const dayStartValue = startingPlayerCount * 0.6 + 3;
+  const dayEndValue = 3;
+  const nightTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
+  const nightStartValue = 4;
+  const nightEndValue = 1;
 
-function roundToNearestQuarter(n) {
-  return Math.round(n * 4) / 4;
-}
-
-function generateExponentialDecay(startValue, endValue, totalNumbers) {
-  let values = [];
-  let b = -Math.log(endValue / startValue);
-  let step = 1 / (totalNumbers - 1);
-
-  for (let i = 0; i < totalNumbers; i++) {
-    let x = i * step;
-    let y = startValue * Math.exp(-b * x);
-    if (y < endValue) {
-      y = endValue;
-    }
-    values.push(roundToNearestQuarter(y));
+  function roundToNearestQuarter(n) {
+    return Math.round(n * 4) / 4;
   }
 
-  return values;
+  function generateExponentialDecay(startValue, endValue, totalNumbers) {
+    let values = [];
+    let b = -Math.log(endValue / startValue);
+    let step = 1 / (totalNumbers - 1);
+
+    for (let i = 0; i < totalNumbers; i++) {
+      let x = i * step;
+      let y = startValue * Math.exp(-b * x);
+      if (y < endValue) {
+        y = endValue;
+      }
+      values.push(roundToNearestQuarter(y));
+    }
+
+    return values;
+  }
+
+  let dayDecayValues = generateExponentialDecay(
+    dayStartValue,
+    dayEndValue,
+    dayTotalNumbers
+  );
+  let nightDecayValues = generateExponentialDecay(
+    nightStartValue,
+    nightEndValue,
+    nightTotalNumbers
+  );
+
+  function convertToSeconds(values) {
+    return values.map((value) => value * 60);
+  }
+
+  const dayDecayValuesSeconds = convertToSeconds(dayDecayValues);
+  const nightDecayValuesSeconds = convertToSeconds(nightDecayValues);
+
+  timeValues = {
+    day: dayDecayValuesSeconds,
+    endOfDay: nightDecayValuesSeconds,
+  };
 }
 
-let dayDecayValues = generateExponentialDecay(
-  dayStartValue,
-  dayEndValue,
-  dayTotalNumbers
-);
+updateTimeValues(10);
 
-let nightDecayValues = generateExponentialDecay(
-  nightStartValue,
-  nightEndValue,
-  nightTotalNumbers
-);
-
-function convertToSeconds(values) {
-  return values.map((value) => value * 60);
-}
-
-const dayDecayValuesSeconds = convertToSeconds(dayDecayValues);
-const nightDecayValuesSeconds = convertToSeconds(nightDecayValues);
+document.getElementById("updateButton").addEventListener("click", function () {
+  let inputCount = parseInt(
+    prompt(
+      "Please enter a number between 5 and 15: (this will determine the default timer length)"
+    )
+  );
+  if (inputCount >= 5 && inputCount <= 15) {
+    updateTimeValues(inputCount);
+  } else {
+    alert("Please enter a valid number between 5 and 15.");
+  }
+});
 
 // State variables
 let isMuted = false;
@@ -72,10 +92,6 @@ let phase = 2;
 const DAY = 0,
   ENDOFDAY = 1,
   NIGHT = 2;
-let timeValues = {
-  day: dayDecayValuesSeconds,
-  endOfDay: nightDecayValuesSeconds,
-};
 let stepSize = 15;
 let volume = [50, 30, 80];
 let timeOfDayText = document.getElementById("timeOfDayText");


### PR DESCRIPTION
This will generate an array based on the player count which will then be applied to the timer, so we don't have to manually input the array's for each player count. It will take a range (startValue and endValue), then apply an exponential decay where the amount of points on the line is determined by totalNumbers. For example:

startValue = 12 
endValue = 3
totalNumbers = 12

The array generated:
[12, 10.5, 9.25, 8.25, 7.25, 6.5, 5.75, 5, 4.5, 3.75, 3.5, 3]

This will allow for easy adjusting down the line. In the future, we can give players the option to adjust these numbers, as opposed to inputing an entire array of numbers.

**Need to add**
* Switch the prompt to a button 
* A default when startingPlayerCount is not set