### PR TITLE
Implement settings dialog

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,107 @@
+function calcTimerStartEndValues(startingPlayerCount) {
+  return {
+    totalNumbers: startingPlayerCount - startingPlayerCount / 5,
+    dayStartValue: startingPlayerCount * 0.4 +2,
+    dayEndValue: 2,
+    nightStartValue: startingPlayerCount * 0.1 +1,
+    nightEndValue: 1
+  };
+}
+
+function roundToNearestQuarter(n) {
+  return Math.round(n * 4) / 4;
+}
+
+function generateExponentialDecay(startValue, endValue, totalNumbers) {
+  let values = [];
+  let b = -Math.log(endValue / startValue);
+  let step = 1 / (totalNumbers - 1);
+
+  for (let i = 0; i < totalNumbers; i++) {
+    let x = i * step;
+    let y = startValue * Math.exp(-b * x);
+    if (y < endValue) {
+      y = endValue;
+    }
+    values.push(roundToNearestQuarter(y));
+  }
+  return values;
+}
+
+function convertToSeconds(values) {
+  return values.map((value) => value * 60);
+}
+
+function findKey(search, map) {
+  if (search.length == 1) search = search.toUpperCase();
+  for (const key in map) {
+    if (
+      (typeof map[key] === "string" && map[key] === search) ||
+      (typeof map[key] === "object" && map[key].includes(search))
+    ) {
+      return key;
+    }
+  }
+  return null;
+}
+
+function formatTime(seconds) {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  const formattedMinutes = minutes < 10 ? "0" + minutes : minutes;
+  const formattedSeconds =
+    remainingSeconds < 10 ? "0" + remainingSeconds : remainingSeconds;
+  return `${formattedMinutes}:${formattedSeconds}`;
+}
+
+function parseTime(timeValue) {
+  timeValue = timeValue.replace(',', '.');
+  let parsedTime = 0;
+  if (/^-?\d*\.?\d+m?$/.test(timeValue)) {
+    if (typeof timeValue === "string") timeValue = timeValue.replace("m", "");
+    parsedTime = Math.round(timeValue * 60);
+  } else if (timeValue.includes(":")) {
+    timeValue = timeValue.split(":");
+    if (timeValue[0].startsWith("-") || timeValue[1].startsWith("-")) {
+      return 0;
+    }
+    parsedTime = timeValue[0] * 60 + timeValue[1] * 1;
+  } else if (timeValue.endsWith("s")) {
+    parsedTime = Math.round(timeValue.substr(0, timeValue.length - 1));
+  }
+  return parsedTime;
+}
+
+function updateCharacterAmounts(userInput) {
+  const characterAmounts = {
+    5: [3, 0, 1, 1],
+    6: [3, 1, 1, 1],
+    7: [5, 0, 1, 1],
+    8: [5, 1, 1, 1],
+    9: [5, 2, 1, 1],
+    10: [7, 0, 2, 1],
+    11: [7, 1, 2, 1],
+    12: [7, 2, 2, 1],
+    13: [9, 0, 3, 1],
+    14: [9, 1, 3, 1],
+    15: [9, 2, 3, 1],
+  };
+  const numbersArray = characterAmounts[userInput];
+  document.getElementById("townsfolkAmount").textContent = numbersArray[0];
+  document.getElementById("outsiderAmount").textContent = numbersArray[1];
+  document.getElementById("minionAmount").textContent = numbersArray[2];
+  document.getElementById("demonAmount").textContent = numbersArray[3];
+}
+
+function updateTravelerAmount(userInput) {
+  document.getElementById("travelerAmount").textContent = userInput;
+}
+
+function updatePlayerCount(player, traveller) {
+  updateTravelerAmount(traveller);
+  updateCharacterAmounts(player);
+  document.getElementById("heartNumber").innerText =
+    player + traveller;
+  document.getElementById("voteNumber").innerText =
+    player + traveller;
+}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
     />
     <link rel="stylesheet" href="style.css" />
+    <link rel="preload" as="image" href="images/village-end-of-day.webp" />
+    <link rel="preload" as="image" href="images/village-day.webp" />
+    <link rel="preload" as="image" href="images/village-night.webp" />
     <link rel="icon" type="image/x-icon" href="images/favicon.png" />
   </head>
   <body>
@@ -42,13 +45,15 @@
           <span id="dayValue">1</span>
         </div>
         <div>
-          <button id="updateButton">Enter Player Count</button>
+          <button id="settingsButton">
+            <i class="fas fa-cog"></i>
+          </button>
           <button id="muteButton">
             <i class="fas fa-volume-up"></i>
           </button>
           <!--<a href="spotify.html" target="_blank"><button class="fab fa-spotify"></button></a>-->
           <button id="infoIcon" class="fas fa-info-circle"></button>
-          <div id="dialogueBox" class="hidden">
+          <div id="dialogueBox" class="noDisplay">
             <span
               id="closeButton"
               style="
@@ -57,6 +62,7 @@
                 font-size: 20px;
                 font-weight: bold;
                 padding: 0 10px;
+                color: rgb(61, 61, 61);
               "
               >&times;</span
             >
@@ -73,46 +79,7 @@
               be shortened when advancing the days (to account for fewer alive
               people as the game progresses). Hope you enjoy!
             </p>
-            <p>You may also control this app using keyboard-shortcuts:</p>
-            <dl>
-              <dt><span class="key">Space</span></dt>
-              <dd>Start or stop the timer</dd>
-              <dt><span class="key">Backspace</span></dt>
-              <dd>Reset the timer</dd>
-              <dt><span class="key">Z</span></dt>
-              <dd>Edit the timer</dd>
-              <dt>
-                <span class="key">Up</span>/<span class="key">Right</span>/<span
-                  class="key"
-                  >+</span
-                >,
-                <br />
-                <span class="key">Down</span>/<span class="key">Left</span
-                >/<span class="key">-</span>
-              </dt>
-              <dd>Quick adjust the timer</dd>
-              <dt><span class="key">R</span></dt>
-              <dd>Immediate recall town</dd>
-              <dt><span class="key">N</span>/<span class="key">Enter</span></dt>
-              <dd>Move to next phase (night/day/end of day/night)</dd>
-              <dt><span class="key">P</span></dt>
-              <dd>Move back the previous phase (night/end of day/day/night)</dd>
-              <dt>
-                <span class="key">F1</span>, <span class="key">F2</span>,
-                <span class="key">F3</span>
-              </dt>
-              <dd>Goto current day's day/end of day/night</dd>
-              <dt><span class="key">F4</span></dt>
-              <dd>Toggle Mute</dd>
-              <dt><span class="key">F</span></dt>
-              <dd>Toggle Fullscreen</dd>
-              <dt><span class="key">Q</span></dt>
-              <dd>Toggle this dialogue</dd>
-            </dl>
-            <p>
-              To use the experimental Spotify integration visit
-              <a href="/spotify.html" target="_blank">/spotify.html</a>.
-            </p>
+            <p>You may also control this app using configurable keyboard-shortcuts.</p>
             <p>-</p>
             <p class="disclaimer">
               Disclaimer: Clocktowertimer is an open source project and is not
@@ -123,7 +90,7 @@
           </div>
         </div>
       </div>
-      <div>
+      <div id="roleDistributionContainer">
         <img src="images/townsfolk.png" />
         <span id="townsfolkAmount">0</span> <span>/</span>
         <span id="outsiderAmount">0</span>
@@ -168,7 +135,125 @@
         <img src="images/box.png" />
       </div>
     </div>
+    <dialog id="settings">
+      <form method="dialog">
+        <h1>Settings</h1>
+        <fieldset name="gamestate">
+          <legend>Gamestate</legend>
+          <label for="playerCountInput">Starting Player Count</label>
+          <input type="number" id="playerCountInput" class="pregame" min="5" max="15" step="1" value=""/>
+          <label for="linkedTimerInput">Linked Timer</label>
+          <input type="checkbox" id="linkedTimerInput" class="pregame" />
+          <label for="travellerCountInput">Traveller Count</label>
+          <input type="number" id="travellerCountInput" class="" min="0" max="5" step="1" value=""/>
+          <div id="settingsEditTimer">
+            <span>Day 1</span>
+            <label for="day1TimerInput"><i class="fa fa-comments"></i></label>
+            <input type="text" id="day1TimerInput" class="pregame" />
+            <label for="endofday1TimerInput"><i class="fa fa-skull"></i></label>
+            <input type="text" id="endofday1TimerInput" class="pregame" />
+            <span id="settingsDayN">Day N</span>
+            <label for="dayNTimerInput"><i class="fa fa-comments"></i></label>
+            <input type="text" id="dayNTimerInput" class="pregame" />
+            <label for="endofdayNTimerInput"><i class="fa fa-skull"></i></label>
+            <input type="text" id="endofdayNTimerInput" class="pregame" />
+          </div>
+          <div id="settingsTimerPreview"></div>
+        </fieldset>
+        <fieldset name="features">
+          <legend>Features</legend>
+          <label for="featureSpotify">Spotify</label>
+          <input type="checkbox" id="featureSpotify" />
+          <label for="featureRoles">Role Distribution</label>
+          <input type="checkbox" id="featureRoles" />
+          <label for="featureVotes">Alive/Votes</label>
+          <input type="checkbox" id="featureVotes" />
+        </fieldset>
+        <fieldset name="spotify">
+          <legend>Spotify</legend>
+          <a href="spotify.html" target="_blank">Connect Clocktowertimer to Spotify API</a>
+          <br>
+          <span>Adjust Volume:</span>
+          <label for="nightVolumeInput"><i class="fa fa-moon"></i></label>
+          <input type="number" id="nightVolumeInput" min="0" max="100" step="1" value="" />
+          <label for="dawnVolumeInput"><i class="fa fa-comments"></i></label>
+          <input type="number" id="dawnVolumeInput" min="0" max="100" step="1" value="" />
+          <label for="duskVolumeInput"><i class="fa fa-skull"></i></label>
+          <input type="number" id="duskVolumeInput" min="0" max="100" step="1" value="" />
+          <div>
+            <span>Test:</span>
+            <button onclick="spotifyTogglePlay(true);return false;">Toggle Play/Pause</button>
+            <br>
+            <button onclick="spotifyVolume(document.getElementById('nightVolumeInput').value, true);return false;">Volume at Night</button>
+            <button onclick="spotifyVolume(document.getElementById('dawnVolumeInput').value, true);return false;">Volume at Dawn</button>
+            <button onclick="spotifyVolume(document.getElementById('duskVolumeInput').value, true);return false;">Volume at Dusk</button>
+          </div>
+        </fieldset>
+        <fieldset name="timer">
+          <legend>Timer</legend>
+          <label for="stepSizeInput">Step width for +/-</label>
+          <input type="number" id="stepSizeInput" min="0" max="120" step="1" value="" />
+        </fieldset>
+        <fieldset name="keybindings">
+          <legend>Keybindings</legend>
+          <label for="timerstart">Start/Stop Timer</label>
+          <button id="timerstart" class="key"></button>
+          <label for="recall">Recall Town</label>
+          <button id="recall" class="key"></button>
+          <br>
+          <label for="phasenext">Next Phase</label>
+          <button id="phasenext" class="key"></button>
+          <button id="phasenextalt" class="key"></button>
+          <label for="phaseprev">Previous Phase</label>
+          <button id="phaseprev" class="key"></button>
+          <br>
+          <label for="timerreset">Reset Timer</label>
+          <button id="timerreset" class="key"></button>
+          <label for="timeredit">Edit Timer</label>
+          <button id="timeredit" class="key"></button>
+          <br>
+          <label for="timerplus">Increase Timer</label>
+          <button id="timerplus" class="key"></button>
+          <button id="timerplusalt" class="key"></button>
+          <button id="timerplusalt2" class="key"></button>
+          <br>
+          <label for="timerminus">Decrease Timer</label>
+          <button id="timerminus" class="key"></button>
+          <button id="timerminusalt" class="key"></button>
+          <button id="timerminusalt2" class="key"></button>
+          <br>
+          <label for="togglemute">Toggle Mute</label>
+          <button id="togglemute" class="key"></button>
+          <label for="togglefullscreen">Toggle Fullscreen</label>
+          <button id="togglefullscreen" class="key"></button>
+          <label for="toggleinfo">Toggle Info</label>
+          <button id="toggleinfo" class="key"></button>
+          <label for="togglesettings">Open Settings</label>
+          <button id="togglesettings" class="key"></button>
+        </fieldset>
+        <button type="submit" value="abort" class="abort">Abort Settings</button>
+        <button type="submit" value="save">Save Settings</button>
+      </form>
+    </dialog>
+    <dialog id="timerEditDialog">
+      <form method="dialog">
+        <label for="timerEditInput">Timer Value</label>
+        <br>
+        <input type="text" id="timerEditInput" autofocus>
+        <br>
+        <button value="confirm">Set Timer</button>
+      </form>
+    </dialog>
+    <dialog id="messageDialog">
+      <form method="dialog">
+        <h1></h1>
+        <p></p>
+        <button type=submit" value="confirm">OK</button>
+      </form>
+    </dialog>
 
+    <script src="helper.js"></script>
+    <script src="settings.js"></script>
     <script src="spotify.js"></script>
     <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -10,7 +10,7 @@ const toggleTimeOfDayButton = document.getElementById("toggleTimeOfDayButton");
 const dayValue = document.getElementById("dayValue");
 const body = document.body;
 const muteButton = document.getElementById("muteButton");
-let timeValues = {}; // Initialize `timeValues` at a higher scope
+let timeValues = {day: [], endOfDay: []}; // Initialize `timeValues` at a higher scope
 
 function increase(id) {
   const element = document.getElementById(id);
@@ -40,109 +40,6 @@ document.getElementById("decreaseVote").addEventListener("click", function () {
   decrease("voteNumber");
 });
 
-function updateTimeValues(playerCount) {
-  const startingPlayerCount = playerCount;
-  const dayTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
-  const dayStartValue = startingPlayerCount * 0.4 + 2;
-  const dayEndValue = 2;
-  const nightTotalNumbers = startingPlayerCount - startingPlayerCount / 5;
-  const nightStartValue = startingPlayerCount * 0.1 + 1;
-  const nightEndValue = 1;
-
-  function roundToNearestQuarter(n) {
-    return Math.round(n * 4) / 4;
-  }
-
-  function generateExponentialDecay(startValue, endValue, totalNumbers) {
-    let values = [];
-    let b = -Math.log(endValue / startValue);
-    let step = 1 / (totalNumbers - 1);
-
-    for (let i = 0; i < totalNumbers; i++) {
-      let x = i * step;
-      let y = startValue * Math.exp(-b * x);
-      if (y < endValue) {
-        y = endValue;
-      }
-      values.push(roundToNearestQuarter(y));
-    }
-
-    return values;
-  }
-
-  let dayDecayValues = generateExponentialDecay(
-    dayStartValue,
-    dayEndValue,
-    dayTotalNumbers
-  );
-  let nightDecayValues = generateExponentialDecay(
-    nightStartValue,
-    nightEndValue,
-    nightTotalNumbers
-  );
-
-  function convertToSeconds(values) {
-    return values.map((value) => value * 60);
-  }
-
-  const dayDecayValuesSeconds = convertToSeconds(dayDecayValues);
-  const nightDecayValuesSeconds = convertToSeconds(nightDecayValues);
-
-  timeValues = {
-    day: dayDecayValuesSeconds,
-    endOfDay: nightDecayValuesSeconds,
-  };
-}
-
-updateTimeValues(10);
-
-function updateCharacterAmounts(userInput) {
-  const characterAmounts = {
-    5: [3, 0, 1, 1],
-    6: [3, 1, 1, 1],
-    7: [5, 0, 1, 1],
-    8: [5, 1, 1, 1],
-    9: [5, 2, 1, 1],
-    10: [7, 0, 2, 1],
-    11: [7, 1, 2, 1],
-    12: [7, 2, 2, 1],
-    13: [9, 0, 3, 1],
-    14: [9, 1, 3, 1],
-    15: [9, 2, 3, 1],
-  };
-
-  const numbersArray = characterAmounts[userInput];
-
-  document.getElementById("townsfolkAmount").textContent = numbersArray[0];
-  document.getElementById("outsiderAmount").textContent = numbersArray[1];
-  document.getElementById("minionAmount").textContent = numbersArray[2];
-  document.getElementById("demonAmount").textContent = numbersArray[3];
-}
-
-function updateTravelerAmount(userInput) {
-  document.getElementById("travelerAmount").textContent = userInput;
-}
-
-document.getElementById("updateButton").addEventListener("click", function () {
-  let inputCount = parseInt(
-    prompt(
-      "Please enter a number between 5 and 15: (this will determine the default timer length)"
-    )
-  );
-  let travelorCount = parseInt(prompt("How many travelers are in your game?"));
-  updateTravelerAmount(travelorCount);
-  if (inputCount >= 5 && inputCount <= 15) {
-    updateTimeValues(inputCount);
-    updateCharacterAmounts(inputCount);
-    document.getElementById("heartNumber").innerText =
-      inputCount + travelorCount;
-    document.getElementById("voteNumber").innerText =
-      inputCount + travelorCount;
-  } else {
-    alert("Please enter a valid number between 5 and 15.");
-  }
-});
-
 // State variables
 let isMuted = false;
 let countdown;
@@ -154,41 +51,10 @@ let phase = 2;
 const DAY = 0,
   ENDOFDAY = 1,
   NIGHT = 2;
-let stepSize = 15;
-let volume = [50, 30, 80];
 let timeOfDayText = document.getElementById("timeOfDayText");
-let keybindings = {
-  startstop: [" ", "Spacebar"],
-  reset: "Backspace",
-  timer: "Z",
-  timeplus: ["Up", "ArrowUp", "Right", "ArrowRight", "+"],
-  timeminus: ["Down", "ArrowDown", "Left", "ArrowLeft", "-"],
-  recall: "R",
-  nextphase: ["N", "Enter"],
-  previousphase: "P",
-  day: "F1",
-  endOfDay: "F2",
-  night: "F3",
-  nextday: "F4",
-  toggleinfo: "Q",
-  mute: "D",
-  fullscreen: "F",
-};
-
-function findKey(search, map) {
-  if (search.length == 1) search = search.toUpperCase();
-  for (const key in map) {
-    if (
-      (typeof map[key] === "string" && map[key] === search) ||
-      (typeof map[key] === "object" && map[key].includes(search))
-    ) {
-      return key;
-    }
-  }
-  return null;
-}
 
 function parseKeydown(e) {
+  if (document.querySelector('dialog[open]') != null) return;
   let action = findKey(e.key, keybindings);
   switch (action) {
     case "startstop":
@@ -221,15 +87,10 @@ function parseKeydown(e) {
       advanceTime();
       break;
     case "toggleinfo":
-      const dialogueBox = document.getElementById("dialogueBox");
-      if (dialogueBox.classList.contains("hidden")) {
-        showInfo();
-      } else {
-        exitInfo();
-      }
+      toggleInfo();
       break;
     case "mute":
-      mute();
+      toggleMute();
       break;
     case "fullscreen":
       if (
@@ -259,6 +120,9 @@ function parseKeydown(e) {
         }
       }
       break;
+    case "togglesettings":
+      openSettings();
+      break;
     default:
       console.debug(`No Action for key: ${e.key} (${e.keyCode})`);
   }
@@ -266,7 +130,6 @@ function parseKeydown(e) {
     e.preventDefault();
   }
 }
-
 document.addEventListener("keydown", parseKeydown);
 
 function isDay() {
@@ -281,102 +144,29 @@ function isNight() {
   return phase == NIGHT;
 }
 
-function applyConfig(config) {
-  if (config.timeValues) {
-    if (!("day" in config.timeValues && "endOfDay" in config.timeValues)) {
-      console.log(
-        "no config applied: missing key in timeValues (day, endOfDay)"
-      );
-    } else {
-      let invalidElement = false;
-      for (const key in config.timeValues) {
-        config.timeValues[key] = config.timeValues[key].map((elem) => {
-          if (!isNaN(elem) && elem > 0) {
-            // formatted e.g. 480 (already meaning seconds), no conversion needed
-            return elem;
-          }
-          parsedTime = parseTime(elem);
-          if (parsedTime <= 0) {
-            invalidElement = String(elem);
-            return elem;
-          }
-          // formatted e.g. 8m, 8:00 or 480s, converted to 480
-          return parsedTime;
-        });
-      }
-      if (invalidElement) {
-        console.log(
-          `no config applied: ${invalidElement} in timeValues is of an invalid format (or <= 0)`
-        );
-      } else {
-        console.log(
-          `config applied: "timeValues":${JSON.stringify(config.timeValues)}`
-        );
-        timeValues = config.timeValues;
-      }
-    }
-  }
-  if (config.stepSize) {
-    if (isNaN(config.stepSize) || config.stepSize <= 0) {
-      console.log("no config applied: stepSize is NaN (or <= 0)");
-    } else {
-      console.log(`config applied: "stepSize":${config.stepSize}`);
-      stepSize = config.stepSize;
-    }
-  }
-  if (config.volume) {
-    let invalidElement = false;
-    config.volume.map((elem) => {
-      if (isNaN(elem) || elem < 0 || elem > 100) {
-        invalidElement = String(elem);
-      }
-      return elem;
-    });
-    if (invalidElement) {
-      console.log(
-        `no config applied: ${invalidElement} in volume is of an invalid format (or not between 0 and 100)`
-      );
-    } else {
-      console.log(`config applied: "volume":${JSON.stringify(config.volume)}`);
-      volume = config.volume;
-    }
-  }
+function openSettings() {
+  const settings = document.querySelector('#settings');
+  settings.returnValue = 'none';
+  settings.showModal();
 }
 
-function getCurrentConfigUrl() {
-  return encodeURI(
-    `${window.location.href.split("?")[0]}?timeValues=${JSON.stringify(
-      timeValues
-    )}&stepSize=${stepSize}&volume=${JSON.stringify(volume)}`
-  );
-}
+document.getElementById('settingsButton').addEventListener('click', openSettings);
+openSettings();
 
-function formatTime(seconds) {
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  const formattedMinutes = minutes < 10 ? "0" + minutes : minutes;
-  const formattedSeconds =
-    remainingSeconds < 10 ? "0" + remainingSeconds : remainingSeconds;
-  return `${formattedMinutes}:${formattedSeconds}`;
-}
+document.querySelector('#settings').addEventListener('cancel', (e) => {
+  if (document.querySelector('#settings').returnValue === 'none') e.preventDefault();
+});
 
-function parseTime(timeValue) {
-  if (/^-?\d*\.?\d+m?$/.test(timeValue)) {
-    if (typeof timeValue === "string") timeValue = timeValue.replace("m", "");
-    parsedTime = Math.round(timeValue * 60);
-  } else if (timeValue.includes(":")) {
-    timeValue = timeValue.split(":");
-    if (timeValue[0].startsWith("-") || timeValue[1].startsWith("-")) {
-      return 0;
+document.querySelector('#settings').addEventListener('close', (e) => {
+  if (document.querySelector('#settings').returnValue === 'save') {
+    if (!body.classList.contains('gameRunning')) {
+      body.classList.add('gameRunning');
     }
-    parsedTime = timeValue[0] * 60 + timeValue[1] * 1;
-  } else if (timeValue.endsWith("s")) {
-    parsedTime = Math.round(timeValue.substr(0, timeValue.length - 1));
-  } else {
-    parsedTime = 0;
+    saveSettings();
   }
-  return parsedTime;
-}
+  loadSettings();
+  document.querySelector('#settingsButton').blur();
+});
 
 function displayTimeLeft(seconds) {
   timeDisplay.textContent = formatTime(seconds);
@@ -505,26 +295,34 @@ incrementTimeButton.addEventListener("click", incrementTimer);
 
 function editTimer() {
   if (!isTimerRunning && !isNight()) {
-    const userTime = prompt(
-      "New Time:\nPossible formats: 7.5, 7:30, 450s\nPossible range: 1 second - 59:99"
-    );
-    if (userTime != null) {
-      const parsedTime = parseTime(userTime);
-      if (parsedTime <= 0 || parsedTime > 3599) {
-        alert(
-          `Invalid input '${userTime}'\nPossible formats: 7.5, 7:30, 450s\nPossible range: 1 second - 59:59`
-        );
-        return;
-      }
-      defaultTime = parsedTime;
-      timeRemaining = defaultTime;
-      displayTimeLeft(timeRemaining);
-    }
+    document.querySelector('#timerEditDialog').returnValue = 'none';
+    document.querySelector('#timerEditDialog').showModal();
   }
-  editTimeButton.blur();
 }
 
 editTimeButton.addEventListener("click", editTimer);
+
+document.querySelector('#timerEditDialog').addEventListener('close', (e) => {
+  const dialog = document.querySelector('#timerEditDialog');
+  const userTime = dialog.querySelector('input').value;
+  dialog.querySelector('input').value = '';
+  editTimeButton.blur();
+  if (dialog.returnValue === 'none') return;
+  if (userTime !== '') {
+      const parsedTime = parseTime(userTime);
+      if (parsedTime <= 0 || parsedTime > 3599) {
+        const message = document.querySelector('#messageDialog');
+        message.querySelector('h1').innerText = 'Invalid Timer Value';
+        message.querySelector('p').innerHTML = `Invalid input '${userTime}'<br>Possible formats: 7.5, 7:30, 450s<br>Possible range: 1 second - 59:59`;
+        message.showModal();
+        return;
+      } else {
+        defaultTime = parsedTime;
+        timeRemaining = defaultTime;
+        displayTimeLeft(timeRemaining);
+      }
+    }
+});
 
 function decrementTimer() {
   if (!isTimerRunning && !isNight()) {
@@ -537,7 +335,7 @@ function decrementTimer() {
 
 decrementTimeButton.addEventListener("click", decrementTimer);
 
-function mute() {
+function toggleMute() {
   isMuted = !isMuted;
   const icon = muteButton.querySelector("i");
   if (isMuted) {
@@ -548,7 +346,7 @@ function mute() {
   muteButton.blur();
 }
 
-muteButton.addEventListener("click", mute);
+muteButton.addEventListener("click", toggleMute);
 
 function setTimerToZero() {
   timeRemaining = 0;
@@ -602,21 +400,18 @@ function advanceTime() {
 
 toggleTimeOfDayButton.addEventListener("click", advanceTime);
 
-function showInfo() {
-  const dialogueBox = document.getElementById("dialogueBox");
-  dialogueBox.classList.remove("hidden");
-  dialogueBox.style.display = "block";
+function toggleInfo() {
+  const dialogueBox = document.querySelector("#dialogueBox");
+  if (dialogueBox.classList.contains("noDisplay")) {
+    dialogueBox.classList.remove("noDisplay");
+  } else {
+    dialogueBox.classList.add("noDisplay");
+  }
+  document.querySelector('#infoIcon').blur();
 }
 
-document.getElementById("infoIcon").addEventListener("click", showInfo);
-
-function exitInfo() {
-  const dialogueBox = document.getElementById("dialogueBox");
-  dialogueBox.classList.add("hidden");
-  dialogueBox.style.display = "none";
-}
-
-document.getElementById("closeButton").addEventListener("click", exitInfo);
+document.querySelector('#infoIcon').addEventListener('click', toggleInfo);
+document.querySelector('#closeButton').addEventListener('click', toggleInfo);
 
 function updateToggleButtonText() {
   toggleTimeOfDayButton.innerHTML = isDay()
@@ -633,14 +428,6 @@ function updateSpanText() {
     ? "End of Day"
     : "Night";
 }
-
-const config = {};
-const urlParams = new URLSearchParams(window.location.search);
-for (const [key, value] of urlParams.entries()) {
-  config[key] = JSON.parse(value);
-}
-applyConfig(config);
-console.log(getCurrentConfigUrl());
 
 updateToggleButtonText();
 updateBackground();

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,246 @@
+let keybindings = {
+  startstop: [" ", "Spacebar"],
+  reset: "Backspace",
+  timer: "Z",
+  timeplus: ["Up", "ArrowUp", "Right", "ArrowRight", "+"],
+  timeminus: ["Down", "ArrowDown", "Left", "ArrowLeft", "-"],
+  recall: "R",
+  nextphase: ["N", "Enter"],
+  previousphase: "P",
+  toggleinfo: "I",
+  mute: "D",
+  fullscreen: "F",
+  togglesettings: 'Q',
+};
+let stepSize = 15;
+let volume = [50, 30, 80];
+
+function getSetting(key, def=null) {
+  const setting = localStorage.getItem(key);
+  if (setting == null || setting == 'undefined') {
+    return def;
+  }
+  return setting;
+}
+function getBooleanSetting(key, def = false) {
+  const setting = getSetting(key, def);
+  if (typeof setting == 'string') {
+    return setting.toLowerCase() === 'true';
+  }
+  return setting === true;
+}
+
+function getNumericSetting(key, def=0) {
+  const setting = getSetting(key, def);
+  return Number(setting);
+}
+
+function setSetting(key, value) {
+  localStorage.setItem(key, value);
+}
+
+/**
+ * Load settings from **localStorage** and apply them to the app
+ */
+function loadSettings() {
+  const playercount = document.getElementById('playerCountInput').value = getNumericSetting('settings_game_playercount', 10);
+  document.getElementById('linkedTimerInput').checked = getBooleanSetting('settings_game_linkedtimer', true);
+  settingsLinkedTimer();
+  const travellercount = document.getElementById('travellerCountInput').value = getNumericSetting('settings_game_travellercount', 0);
+  updatePlayerCount(playercount, travellercount);
+  const timerValues = calcTimerStartEndValues(playercount);
+  document.getElementById('day1TimerInput').value = formatTime(roundToNearestQuarter(getNumericSetting('settings_game_day1', timerValues['dayStartValue']))*60);
+  document.getElementById('endofday1TimerInput').value = formatTime(roundToNearestQuarter(getNumericSetting('settings_game_night1', timerValues['nightStartValue']))*60);
+  document.getElementById('settingsDayN').innerHTML = `Day ${Math.ceil(timerValues['totalNumbers'])}`;
+  document.getElementById('dayNTimerInput').value = formatTime(roundToNearestQuarter(getNumericSetting('settings_game_dayn', timerValues['dayEndValue']))*60);
+  document.getElementById('endofdayNTimerInput').value = formatTime(roundToNearestQuarter(getNumericSetting('settings_game_nightn', timerValues['dayEndValue']))*60);
+  settingsUpdateTimer(true);
+  document.getElementById('featureSpotify').checked = getBooleanSetting('settings_feature_spotify', false);
+  settingsFeatureSpotifyTimer();
+  let featureRoles = document.getElementById('featureRoles').checked = getBooleanSetting('settings_feature_roles', true);
+  if (!featureRoles) document.getElementById('roleDistributionContainer').classList.add('hidden');
+  else document.getElementById('roleDistributionContainer').classList.remove('hidden');
+  let featureVotes = document.getElementById('featureVotes').checked = getBooleanSetting('settings_feature_votes', true);
+  if (!featureVotes) document.getElementById('characterTracker').classList.add('hidden');
+  else document.getElementById('characterTracker').classList.remove('hidden');
+  volume[2] = document.getElementById('nightVolumeInput').value = getNumericSetting('settings_spotify_night', '80');
+  volume[0] = document.getElementById('dawnVolumeInput').value = getNumericSetting('settings_spotify_dawn', '50');
+  volume[1] = document.getElementById('duskVolumeInput').value = getNumericSetting('settings_spotify_dusk', '30');
+  stepSize = document.getElementById('stepSizeInput').value = getNumericSetting('settings_timer_stepsize', '15');
+  let bind1, bind2, bind3;
+  keybindings["startstop"] = document.getElementById('timerstart').innerHTML = getSetting('settings_key_timerstart', 'Spacebar');
+  keybindings["recall"] = document.getElementById('recall').innerHTML = getSetting('settings_key_recall', 'R');
+  bind1 = document.getElementById('phasenext').innerHTML = getSetting('settings_key_phasenext', 'N');
+  bind2 = document.getElementById('phasenextalt').innerHTML = getSetting('settings_key_phasenextalt', 'Enter');
+  keybindings['nextphase'] = [bind1, bind2];
+  keybindings["previousphase"] = document.getElementById('phaseprev').innerHTML = getSetting('settings_key_phaseprev', 'P');
+  keybindings["reset"] = document.getElementById('timerreset').innerHTML = getSetting('settings_key_timerreset', 'Backspace');
+  keybindings["timer"] = document.getElementById('timeredit').innerHTML = getSetting('settings_key_timeredit', 'Z');
+  bind1 = document.getElementById('timerplus').innerHTML = getSetting('settings_key_timerplus', 'ArrowUp');
+  bind2 = document.getElementById('timerplusalt').innerHTML = getSetting('settings_key_timerplusalt', 'ArrowRight');
+  bind3 = document.getElementById('timerplusalt2').innerHTML = getSetting('settings_key_timerplusalt2', '+');
+  keybindings["timeplus"] = [bind1, bind2, bind3];
+  bind1 = document.getElementById('timerminus').innerHTML = getSetting('settings_key_timerminus', 'ArrowDown');
+  bind2 = document.getElementById('timerminusalt').innerHTML = getSetting('settings_key_timerminusalt', 'ArrowLeft');
+  bind3 = document.getElementById('timerminusalt2').innerHTML = getSetting('settings_key_timerminusalt2', '-');
+  keybindings["timeminus"] = [bind1, bind2, bind3];
+  keybindings["mute"] = document.getElementById('togglemute').innerHTML = getSetting('settings_key_togglemute', 'D');
+  keybindings["fullscreen"] = document.getElementById('togglefullscreen').innerHTML = getSetting('settings_key_togglefullscreen', 'F');
+  keybindings["toggleinfo"] = document.getElementById('toggleinfo').innerHTML = getSetting('settings_key_toggleinfo', 'I');
+  keybindings["togglesettings"] = document.getElementById('togglesettings').innerHTML = getSetting('settings_key_togglesettings', 'Q');
+  fillAlternativeKeys(keybindings);
+}
+loadSettings();
+
+function fillAlternativeKeys(keys) {
+  for (const k in keys) {
+    if (typeof keys[k] === 'string') {
+      keys[k] = [keys[k]];
+    }
+    if (keys[k].includes('Spacebar')) keys[k].push(' ');
+    else if (keys[k].includes(' ')) keys[k].push('Spacebar');
+    if (keys[k].includes('Up')) keys[k].push('ArrowUp');
+    else if (keys[k].includes('ArrowUp')) keys[k].push('Up');
+    if (keys[k].includes('Down')) keys[k].push('ArrowDown');
+    else if (keys[k].includes('ArrowDown')) keys[k].push('Down');
+    if (keys[k].includes('Left')) keys[k].push('ArrowLeft');
+    else if (keys[k].includes('ArrowLeft')) keys[k].push('Left');
+    if (keys[k].includes('Right')) keys[k].push('ArrowRight');
+    else if (keys[k].includes('ArrowRight')) keys[k].push('Right');
+  }
+}
+
+/**
+ * Store settings to **localStorage** and apply them to the app
+ */
+function saveSettings() {
+  setSetting('settings_game_playercount', document.getElementById('playerCountInput').value);
+  setSetting('settings_game_linkedtimer', document.getElementById('linkedTimerInput').checked);
+  setSetting('settings_game_travellercount', document.getElementById('travellerCountInput').value);
+  setSetting('settings_game_day1', parseTime(document.getElementById('day1TimerInput').value)/60);
+  setSetting('settings_game_night1', parseTime(document.getElementById('endofday1TimerInput').value)/60);
+  setSetting('settings_game_dayn', parseTime(document.getElementById('dayNTimerInput').value)/60);
+  setSetting('settings_game_nightn', parseTime(document.getElementById('endofdayNTimerInput').value)/60);
+  setSetting('settings_feature_spotify', document.getElementById('featureSpotify').checked);
+  setSetting('settings_feature_roles', document.getElementById('featureRoles').checked);
+  setSetting('settings_feature_votes', document.getElementById('featureVotes').checked);
+  setSetting('settings_spotify_night', document.getElementById('nightVolumeInput').value);
+  setSetting('settings_spotify_dawn', document.getElementById('dawnVolumeInput').value);
+  setSetting('settings_spotify_dusk', document.getElementById('duskVolumeInput').value);
+  setSetting('settings_timer_stepsize', document.getElementById('stepSizeInput').value);
+  setSetting('settings_key_timerstart', document.getElementById('timerstart').innerHTML);
+  setSetting('settings_key_recall', document.getElementById('recall').innerHTML);
+  setSetting('settings_key_phasenext', document.getElementById('phasenext').innerHTML);
+  setSetting('settings_key_phasenextalt', document.getElementById('phasenextalt').innerHTML);
+  setSetting('settings_key_phaseprev', document.getElementById('phaseprev').innerHTML);
+  setSetting('settings_key_timerreset', document.getElementById('timerreset').innerHTML);
+  setSetting('settings_key_timeredit', document.getElementById('timeredit').innerHTML);
+  setSetting('settings_key_timerplus', document.getElementById('timerplus').innerHTML);
+  setSetting('settings_key_timerplusalt', document.getElementById('timerplusalt').innerHTML);
+  setSetting('settings_key_timerplusalt2', document.getElementById('timerplusalt2').innerHTML);
+  setSetting('settings_key_timerminus', document.getElementById('timerminus').innerHTML);
+  setSetting('settings_key_timerminusalt', document.getElementById('timerminusalt').innerHTML);
+  setSetting('settings_key_timerminusalt2', document.getElementById('timerminusalt2').innerHTML);
+  setSetting('settings_key_togglemute', document.getElementById('togglemute').innerHTML);
+  setSetting('settings_key_togglefullscreen', document.getElementById('togglefullscreen').innerHTML);
+  setSetting('settings_key_toggleinfo', document.getElementById('toggleinfo').innerHTML);
+  setSetting('settings_key_togglesettings', document.getElementById('togglesettings').innerHTML);
+}
+
+let keyId = null;
+function waitForKey(e) {
+  keyId = e.target.id;
+  document.querySelectorAll('.key.active').forEach((elem) => {
+    elem.classList.remove('active');
+  });
+  document.getElementById(keyId).classList.add('active');
+  document.addEventListener('keydown', (ke) => {
+    let key = ke.key.length === 1 ? ke.key.toUpperCase() : ke.key;
+    if (key === ' ') key = 'Spacebar';
+    if (key !== 'Escape') {
+      document.getElementById(keyId).innerText = key;
+    }
+    document.getElementById(keyId).classList.remove('active');
+    document.getElementById(keyId).blur();
+    ke.preventDefault();
+  }, {once: true});
+  e.preventDefault(); // prevent dialog from closing
+}
+document.querySelector('#settings').querySelectorAll('.key').forEach((elem) => {
+  elem.addEventListener('click', waitForKey);
+});
+
+function settingsFeatureSpotifyTimer() {
+  let fsSpotify = document.querySelector('fieldset[name="spotify"]');
+  if (document.getElementById('featureSpotify').checked) {
+    fsSpotify.classList.remove('noDisplay');
+  } else {
+    fsSpotify.classList.add('noDisplay');
+  }
+}
+
+function settingsUpdateTimeValues() {
+  const timerValues = calcTimerStartEndValues(document.getElementById('playerCountInput').value);
+  document.getElementById('settingsDayN').innerHTML = `Day ${Math.ceil(timerValues['totalNumbers'])}`;
+  if (document.getElementById('linkedTimerInput').checked) {
+    document.getElementById('day1TimerInput').value = formatTime(roundToNearestQuarter(timerValues['dayStartValue']) * 60);
+    document.getElementById('dayNTimerInput').value = formatTime(roundToNearestQuarter(timerValues['dayEndValue']) * 60);
+    document.getElementById('endofday1TimerInput').value = formatTime(roundToNearestQuarter(timerValues['nightStartValue']) * 60);
+    document.getElementById('endofdayNTimerInput').value = formatTime(roundToNearestQuarter(timerValues['nightEndValue']) * 60);
+  }
+  settingsUpdateTimer();
+}
+document.getElementById('playerCountInput').addEventListener('change', settingsUpdateTimeValues);
+
+document.getElementById('featureSpotify').addEventListener('change', settingsFeatureSpotifyTimer);
+function settingsUpdateTimer(save = false) {
+  const totalNumbers = calcTimerStartEndValues(document.getElementById('playerCountInput').value)['totalNumbers'];
+  const dayStartValue = parseTime(document.getElementById('day1TimerInput').value)/60;
+  const dayEndValue = parseTime(document.getElementById('dayNTimerInput').value)/60;
+  const nightStartValue = parseTime(document.getElementById('endofday1TimerInput').value)/60;
+  const nightEndValue = parseTime(document.getElementById('endofdayNTimerInput').value)/60;
+
+  let dayDecayValues = generateExponentialDecay(
+    dayStartValue,
+    dayEndValue,
+    totalNumbers
+  );
+  let nightDecayValues = generateExponentialDecay(
+    nightStartValue,
+    nightEndValue,
+    totalNumbers
+  );
+  let table = '<table><tr><th>Day</th>';
+  dayDecayValues.forEach((day, idx) => {
+    table += `<td>${idx + 1}</td>`;
+  });
+  table += '</tr><tr><th><i class="fa fa-comments"></i></th>';
+  dayDecayValues.forEach((minutes) => {
+    table += `<td>${formatTime(minutes * 60)}</td>`;
+  });
+  table += '</tr><tr><th><i class="fa fa-skull"></i></th>';
+  nightDecayValues.forEach((minutes) => {
+    table += `<td>${formatTime(minutes * 60)}</td>`;
+  });
+  table += '</tr></table>';
+  document.getElementById('settingsTimerPreview').innerHTML = table;
+  if (save) {
+    timeValues = {
+      day: convertToSeconds(dayDecayValues),
+      endOfDay: convertToSeconds(nightDecayValues),
+    };
+  }
+}
+document.getElementById('day1TimerInput').addEventListener('change', settingsUpdateTimer);
+document.getElementById('dayNTimerInput').addEventListener('change', settingsUpdateTimer);
+document.getElementById('endofday1TimerInput').addEventListener('change', settingsUpdateTimer);
+document.getElementById('endofdayNTimerInput').addEventListener('change', settingsUpdateTimer);
+
+function settingsLinkedTimer() {
+  if (document.getElementById('linkedTimerInput').checked) {
+    document.getElementById('settingsEditTimer').classList.add('autoupdate');
+  } else {
+    document.getElementById('settingsEditTimer').classList.remove('autoupdate');
+  }
+}
+document.getElementById('linkedTimerInput').addEventListener('change', settingsLinkedTimer);

--- a/spotify.auth.js
+++ b/spotify.auth.js
@@ -37,7 +37,7 @@ async function requestUserAuth() {
   const codeVerifier = generateRandomString(64);
   const hashed = await sha256(codeVerifier)
   const codeChallenge = base64encode(hashed);
-  localStorage.setItem('code_verifier', codeVerifier);
+  localStorage.setItem('spotify_code_verifier', codeVerifier);
 
   const params = {
     response_type: 'code',
@@ -53,7 +53,7 @@ async function requestUserAuth() {
 }
 
 async function getAccessToken(code) {
-  let codeVerifier = localStorage.getItem('code_verifier');
+  let codeVerifier = localStorage.getItem('spotify_code_verifier');
   const url = new URL("https://accounts.spotify.com/api/token")
 
   const payload = {

--- a/spotify.html
+++ b/spotify.html
@@ -68,6 +68,7 @@
     <button onclick="spotifyVolume(30)">Volume at Dusk (30%)</button>
 </p>
 </body>
+<script src="settings.js"></script>
 <script src="spotify.auth.js"></script>
 <script src="spotify.js"></script>
 </html>

--- a/spotify.js
+++ b/spotify.js
@@ -1,5 +1,5 @@
 function useSpotify() {
-  return localStorage.getItem('spotify_access_token') && localStorage.getItem('spotify_access_token') !== 'undefined';
+  return getBooleanSetting('settings_feature_spotify') && getSetting('spotify_access_token', false);
 }
 
 async function callSpotify(endpoint, method = 'PUT') {
@@ -13,7 +13,8 @@ async function callSpotify(endpoint, method = 'PUT') {
   return response;
 }
 
-async function spotifyTogglePlay() {
+async function spotifyTogglePlay(force = false) {
+  if (!force && !useSpotify()) return;
   const response = await (await callSpotify('/me/player', 'GET')).json();
   if (response.is_playing) {
     await callSpotify('/me/player/pause');
@@ -22,7 +23,8 @@ async function spotifyTogglePlay() {
   }
 }
 
-function spotifyVolume(volume) {
+function spotifyVolume(volume, force = false) {
+  if (!force && !useSpotify()) return;
   callSpotify(`/me/player/volume?volume_percent=${volume}`);
 }
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ body {
   color: #ffffff;
   display: flex;
   font-family: "Almendra", "Helvetica Neue";
-  font-size: 4em;
+  font-size: 4rem;
 }
 
 img {
@@ -53,7 +53,7 @@ dt {
   grid-column-start: 1;
 }
 
-dt .key {
+.key {
   background-color: #000;
   color: #fff;
   padding: 1px 5px;
@@ -76,6 +76,7 @@ dd {
 #characterTracker img:first-of-type {
   margin-right:80px;
 }
+
 #characterTracker img:nth-of-type(2) {
   height:50px;
 }
@@ -92,7 +93,7 @@ dd {
 }
 
 #characterTracker button {
-  padding:0px;
+  padding:0;
 }
 
 #toggleTimeOfDayButton {
@@ -107,9 +108,8 @@ dd {
   border: 1px solid #9c9c9c;
   padding: 10px;
   border-radius: 5px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   top: 30px;
-  display: none;
 }
 
 #timerContainer {
@@ -123,7 +123,6 @@ dd {
   flex-direction: row;
   align-items: center;
   justify-content: center;
-
 }
 
 #container {
@@ -137,7 +136,7 @@ dd {
 }
 
 #appControls div {
-flex: 1;
+  flex: 1;
 }
 
 .character-counts {
@@ -150,8 +149,12 @@ flex: 1;
   font-size: 0.15em;
 }
 
+.noDisplay {
+  display: none !important;
+}
+
 .hidden {
-  display: none;
+  visibility: hidden !important;
 }
 
 .background-endOfDay {
@@ -207,4 +210,101 @@ flex: 1;
   #toggleTimeOfDayButton {
     font-size: 1em;
   }
+}
+
+dialog::backdrop {
+  background-color: #ffffff88;
+}
+
+dialog {
+  background-color: #000000;
+  color: #ffffff;
+  padding: 20px;
+  border-radius: 50px;
+  font-size: 1.5rem;
+  overflow-y: auto;
+}
+
+dialog h1 {
+  font-size: 2em;
+}
+
+dialog a, dialog a:visited {
+  color: #ffffff;
+}
+
+dialog p {
+  color: #ffffff;
+  font-size: 1.5rem;
+}
+
+dialog a:hover {
+  -webkit-transform: scale(1.2);
+  -ms-transform: scale(1.2);
+  scale: 1.2;
+  color: rgb(177, 36, 36);
+}
+
+dialog .autoupdate input {
+  background-color: #9c9c9c;
+}
+
+.gameRunning dialog input.pregame {
+  background-color: rgb(177, 36, 36);
+}
+
+.abort {
+  display: none;
+}
+
+.gameRunning .abort {
+  display: unset;
+}
+
+dialog fieldset input {
+  width: 75px;
+  margin: 0.5em 1em 0.5em 0.5em;
+  padding: 0.25em;
+  font-size: 1.2rem;
+  text-align: center;
+  border: none;
+  border-radius: 0.5em;
+}
+
+dialog fieldset input[type=checkbox] {
+  width: auto;
+}
+
+dialog fieldset label {
+  margin-left: 1em;
+}
+
+#settingsTimerPreview table {
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px solid white;
+  border-radius: 0.5em;
+  padding: 0.25em;
+}
+
+#settingsTimerPreview table td, #settingsTimerPreview table th {
+  padding: 0 0.25em;
+}
+
+#settingsDayN {
+  margin-left: 2em;
+}
+
+dialog button {
+  font-size: 1.2em;
+}
+
+dialog .key {
+  color: #000000;
+  background-color: #ffffff;
+  font-size: 1em;
+}
+
+dialog .key.active {
+  background-color: rgb(177, 36, 36);
 }


### PR DESCRIPTION
Let me introduce you to the new settings dialog (implements #19):
* settings are stored in local storage (therefore be persistent across reloads and browser restarts)
* settings are open (and may not be closed unless you click "Save Settings" on page load
* after saving initially some fields are marked red as you would usually not change them during the game - but you can
* adjustable Player and Traveller count
* adjustable timer (based on player count using start/end values (which may be overwritten) and the existing function)
* timer options (+/- stepsize)
* enable/disable advanced features: character type distribution, alive/vote counter, spotify
* volume level for (optional) spotify integration
* all hotkeys are configurable similar to the official app (there are some edge cases which i have to fix, but during normal everything is working)

I had to reorganize some code in order to implement this. Also I now removed the old configuration option via URL params (some of which stopped to work after previous changes regarding the calculation of the timer values).

Here are some screenshots:

Settings on page load:
![Bildschirmfoto vom 2024-04-11 23-00-45](https://github.com/tydood/clocktowertimer/assets/5845183/d2cd7c3a-9262-4375-84d3-fa0760d1f086)
Enabled Spotify integration:
![Bildschirmfoto vom 2024-04-11 23-01-03](https://github.com/tydood/clocktowertimer/assets/5845183/ce6c75ea-f866-43a4-bf59-3b44d55e2b5d)
Edit a Hotkey (click the button, then press the new hotkey or Esc to abort):
![Bildschirmfoto vom 2024-04-11 23-01-15](https://github.com/tydood/clocktowertimer/assets/5845183/8922db70-4ecc-4013-a93d-1e7901eb4150)
Settings after initial save:
![Bildschirmfoto vom 2024-04-11 23-01-54](https://github.com/tydood/clocktowertimer/assets/5845183/d15d2049-f4cf-46a9-80a1-f5024a663e41)
Role Distribution and Alive/Vote counter disabled:
![Bildschirmfoto vom 2024-04-11 23-02-27](https://github.com/tydood/clocktowertimer/assets/5845183/d09f6350-379b-42e8-a8d7-88e720c50393)


As a side effekt the "edit timer" function now also uses a HTML dialog. So no more old alert-popup-windows which exit fullscreen mode in some cases (eg in firefox).
![Bildschirmfoto vom 2024-04-11 23-33-05](https://github.com/tydood/clocktowertimer/assets/5845183/74266009-b365-4ef7-87f9-cef2f040f13f)
