### PR TITLE
fix(settings): put scrollbar inside dialog box

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,104 +136,106 @@
       </div>
     </div>
     <dialog id="settings">
-      <form method="dialog">
-        <h1>Settings</h1>
-        <fieldset name="gamestate">
-          <legend>Gamestate</legend>
-          <label for="playerCountInput">Starting Player Count</label>
-          <input type="number" id="playerCountInput" class="pregame" min="5" max="15" step="1" value=""/>
-          <label for="linkedTimerInput">Linked Timer</label>
-          <input type="checkbox" id="linkedTimerInput" class="pregame" />
-          <label for="travellerCountInput">Traveller Count</label>
-          <input type="number" id="travellerCountInput" class="" min="0" max="5" step="1" value=""/>
-          <div id="settingsEditTimer">
-            <span>Day 1</span>
-            <label for="day1TimerInput"><i class="fa fa-comments"></i></label>
-            <input type="text" id="day1TimerInput" class="pregame" />
-            <label for="endofday1TimerInput"><i class="fa fa-skull"></i></label>
-            <input type="text" id="endofday1TimerInput" class="pregame" />
-            <span id="settingsDayN">Day N</span>
-            <label for="dayNTimerInput"><i class="fa fa-comments"></i></label>
-            <input type="text" id="dayNTimerInput" class="pregame" />
-            <label for="endofdayNTimerInput"><i class="fa fa-skull"></i></label>
-            <input type="text" id="endofdayNTimerInput" class="pregame" />
-          </div>
-          <div id="settingsTimerPreview"></div>
-        </fieldset>
-        <fieldset name="features">
-          <legend>Features</legend>
-          <label for="featureSpotify">Spotify</label>
-          <input type="checkbox" id="featureSpotify" />
-          <label for="featureRoles">Role Distribution</label>
-          <input type="checkbox" id="featureRoles" />
-          <label for="featureVotes">Alive/Votes</label>
-          <input type="checkbox" id="featureVotes" />
-        </fieldset>
-        <fieldset name="spotify">
-          <legend>Spotify</legend>
-          <a href="spotify.html" target="_blank">Connect Clocktowertimer to Spotify API</a>
-          <br>
-          <span>Adjust Volume:</span>
-          <label for="nightVolumeInput"><i class="fa fa-moon"></i></label>
-          <input type="number" id="nightVolumeInput" min="0" max="100" step="1" value="" />
-          <label for="dawnVolumeInput"><i class="fa fa-comments"></i></label>
-          <input type="number" id="dawnVolumeInput" min="0" max="100" step="1" value="" />
-          <label for="duskVolumeInput"><i class="fa fa-skull"></i></label>
-          <input type="number" id="duskVolumeInput" min="0" max="100" step="1" value="" />
-          <div>
-            <span>Test:</span>
-            <button onclick="spotifyTogglePlay(true);return false;">Toggle Play/Pause</button>
+      <h1>Settings</h1>
+      <div id="settings-inner">
+        <form method="dialog">
+          <fieldset name="gamestate">
+            <legend>Gamestate</legend>
+            <label for="playerCountInput">Starting Player Count</label>
+            <input type="number" id="playerCountInput" class="pregame" min="5" max="15" step="1" value=""/>
+            <label for="linkedTimerInput">Linked Timer</label>
+            <input type="checkbox" id="linkedTimerInput" class="pregame" />
+            <label for="travellerCountInput">Traveller Count</label>
+            <input type="number" id="travellerCountInput" class="" min="0" max="5" step="1" value=""/>
+            <div id="settingsEditTimer">
+              <span>Day 1</span>
+              <label for="day1TimerInput"><i class="fa fa-comments"></i></label>
+              <input type="text" id="day1TimerInput" class="pregame" />
+              <label for="endofday1TimerInput"><i class="fa fa-skull"></i></label>
+              <input type="text" id="endofday1TimerInput" class="pregame" />
+              <span id="settingsDayN">Day N</span>
+              <label for="dayNTimerInput"><i class="fa fa-comments"></i></label>
+              <input type="text" id="dayNTimerInput" class="pregame" />
+              <label for="endofdayNTimerInput"><i class="fa fa-skull"></i></label>
+              <input type="text" id="endofdayNTimerInput" class="pregame" />
+            </div>
+            <div id="settingsTimerPreview"></div>
+          </fieldset>
+          <fieldset name="features">
+            <legend>Features</legend>
+            <label for="featureSpotify">Spotify</label>
+            <input type="checkbox" id="featureSpotify" />
+            <label for="featureRoles">Role Distribution</label>
+            <input type="checkbox" id="featureRoles" />
+            <label for="featureVotes">Alive/Votes</label>
+            <input type="checkbox" id="featureVotes" />
+          </fieldset>
+          <fieldset name="spotify">
+            <legend>Spotify</legend>
+            <a href="spotify.html" target="_blank">Connect Clocktowertimer to Spotify API</a>
             <br>
-            <button onclick="spotifyVolume(document.getElementById('nightVolumeInput').value, true);return false;">Volume at Night</button>
-            <button onclick="spotifyVolume(document.getElementById('dawnVolumeInput').value, true);return false;">Volume at Dawn</button>
-            <button onclick="spotifyVolume(document.getElementById('duskVolumeInput').value, true);return false;">Volume at Dusk</button>
-          </div>
-        </fieldset>
-        <fieldset name="timer">
-          <legend>Timer</legend>
-          <label for="stepSizeInput">Step width for +/-</label>
-          <input type="number" id="stepSizeInput" min="0" max="120" step="1" value="" />
-        </fieldset>
-        <fieldset name="keybindings">
-          <legend>Keybindings</legend>
-          <label for="timerstart">Start/Stop Timer</label>
-          <button id="timerstart" class="key"></button>
-          <label for="recall">Recall Town</label>
-          <button id="recall" class="key"></button>
-          <br>
-          <label for="phasenext">Next Phase</label>
-          <button id="phasenext" class="key"></button>
-          <button id="phasenextalt" class="key"></button>
-          <label for="phaseprev">Previous Phase</label>
-          <button id="phaseprev" class="key"></button>
-          <br>
-          <label for="timerreset">Reset Timer</label>
-          <button id="timerreset" class="key"></button>
-          <label for="timeredit">Edit Timer</label>
-          <button id="timeredit" class="key"></button>
-          <br>
-          <label for="timerplus">Increase Timer</label>
-          <button id="timerplus" class="key"></button>
-          <button id="timerplusalt" class="key"></button>
-          <button id="timerplusalt2" class="key"></button>
-          <br>
-          <label for="timerminus">Decrease Timer</label>
-          <button id="timerminus" class="key"></button>
-          <button id="timerminusalt" class="key"></button>
-          <button id="timerminusalt2" class="key"></button>
-          <br>
-          <label for="togglemute">Toggle Mute</label>
-          <button id="togglemute" class="key"></button>
-          <label for="togglefullscreen">Toggle Fullscreen</label>
-          <button id="togglefullscreen" class="key"></button>
-          <label for="toggleinfo">Toggle Info</label>
-          <button id="toggleinfo" class="key"></button>
-          <label for="togglesettings">Open Settings</label>
-          <button id="togglesettings" class="key"></button>
-        </fieldset>
-        <button type="submit" value="abort" class="abort">Abort Settings</button>
-        <button type="submit" value="save">Save Settings</button>
-      </form>
+            <span>Adjust Volume:</span>
+            <label for="nightVolumeInput"><i class="fa fa-moon"></i></label>
+            <input type="number" id="nightVolumeInput" min="0" max="100" step="1" value="" />
+            <label for="dawnVolumeInput"><i class="fa fa-comments"></i></label>
+            <input type="number" id="dawnVolumeInput" min="0" max="100" step="1" value="" />
+            <label for="duskVolumeInput"><i class="fa fa-skull"></i></label>
+            <input type="number" id="duskVolumeInput" min="0" max="100" step="1" value="" />
+            <div>
+              <span>Test:</span>
+              <button onclick="spotifyTogglePlay(true);return false;">Toggle Play/Pause</button>
+              <br>
+              <button onclick="spotifyVolume(document.getElementById('nightVolumeInput').value, true);return false;">Volume at Night</button>
+              <button onclick="spotifyVolume(document.getElementById('dawnVolumeInput').value, true);return false;">Volume at Dawn</button>
+              <button onclick="spotifyVolume(document.getElementById('duskVolumeInput').value, true);return false;">Volume at Dusk</button>
+            </div>
+          </fieldset>
+          <fieldset name="timer">
+            <legend>Timer</legend>
+            <label for="stepSizeInput">Step width for +/-</label>
+            <input type="number" id="stepSizeInput" min="0" max="120" step="1" value="" />
+          </fieldset>
+          <fieldset name="keybindings">
+            <legend>Keybindings</legend>
+            <label for="timerstart">Start/Stop Timer</label>
+            <button id="timerstart" class="key"></button>
+            <label for="recall">Recall Town</label>
+            <button id="recall" class="key"></button>
+            <br>
+            <label for="phasenext">Next Phase</label>
+            <button id="phasenext" class="key"></button>
+            <button id="phasenextalt" class="key"></button>
+            <label for="phaseprev">Previous Phase</label>
+            <button id="phaseprev" class="key"></button>
+            <br>
+            <label for="timerreset">Reset Timer</label>
+            <button id="timerreset" class="key"></button>
+            <label for="timeredit">Edit Timer</label>
+            <button id="timeredit" class="key"></button>
+            <br>
+            <label for="timerplus">Increase Timer</label>
+            <button id="timerplus" class="key"></button>
+            <button id="timerplusalt" class="key"></button>
+            <button id="timerplusalt2" class="key"></button>
+            <br>
+            <label for="timerminus">Decrease Timer</label>
+            <button id="timerminus" class="key"></button>
+            <button id="timerminusalt" class="key"></button>
+            <button id="timerminusalt2" class="key"></button>
+            <br>
+            <label for="togglemute">Toggle Mute</label>
+            <button id="togglemute" class="key"></button>
+            <label for="togglefullscreen">Toggle Fullscreen</label>
+            <button id="togglefullscreen" class="key"></button>
+            <label for="toggleinfo">Toggle Info</label>
+            <button id="toggleinfo" class="key"></button>
+            <label for="togglesettings">Open Settings</label>
+            <button id="togglesettings" class="key"></button>
+          </fieldset>
+          <button type="submit" value="abort" class="abort">Abort Settings</button>
+          <button type="submit" value="save">Save Settings</button>
+        </form>
+      </div>
     </dialog>
     <dialog id="timerEditDialog">
       <form method="dialog">

--- a/style.css
+++ b/style.css
@@ -222,7 +222,7 @@ dialog {
   padding: 20px;
   border-radius: 50px;
   font-size: 1.5rem;
-  overflow-y: auto;
+  max-height: calc(100% - 3em);
 }
 
 dialog h1 {
@@ -307,4 +307,15 @@ dialog .key {
 
 dialog .key.active {
   background-color: rgb(177, 36, 36);
+}
+
+#settings {
+  height: auto;
+}
+
+#settings-inner {
+  max-height: calc(100% - 3.5em);
+  overflow: auto;
+  height: auto;
+  margin-top: 0.5em;
 }


### PR DESCRIPTION
The new settings dialog is quite long and therefore shows a scrollbar for its content. This scrollbar is attached to the `<dialog>` element itself, thus making it appear ugly outside of it (see attachment 1).

This PR introduces a new container inside the dialog (`#settings-inner`), that is constrained in the height, therefore attaching the scrollbar to this container instead of the dialog itself.
The code looks like everything of the settings-DOM has been rewritten, but in reality it's just a wrapping with the new container.

The other dialogs are kept intact as is.

A demonstration can be seen in the video (attachment 2).

**Attachment 1** (scrollbar overlaps the rounded edges):
![image](https://github.com/tydood/clocktowertimer/assets/52606896/b0b4c996-aaba-42dc-a069-a929eab0cef8)

**Attachment 2**:
<video autoplay muted src="https://github.com/tydood/clocktowertimer/assets/52606896/fddd601d-4645-403f-b239-e4b6a3ef912c">https://github.com/tydood/clocktowertimer/assets/52606896/fddd601d-4645-403f-b239-e4b6a3ef912c</video>

