### PR TITLE
Add keybindings for trackers (implements #33)

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,6 +339,16 @@
             <label for="phaseprev">Previous Phase</label>
             <button id="phaseprev" class="key"></button>
             <br />
+            <div id="trackerkeys">
+              <label for="aliveplus">Resurrect</label>
+              <button id="aliveplus" class="key"></button>
+              <label for="aliveminus">Death</label>
+              <button id="aliveminus" class="key"></button>
+              <label for="voteplus">Regain Vote</label>
+              <button id="voteplus" class="key"></button>
+              <label for="voteminus">Ghostvote</label>
+              <button id="voteminus" class="key"></button>
+            </div>
             <label for="timerreset">Reset Timer</label>
             <button id="timerreset" class="key"></button>
             <label for="timeredit">Edit Timer</label>

--- a/script.js
+++ b/script.js
@@ -82,6 +82,18 @@ function parseKeydown(e) {
       phase++;
       advanceTime();
       break;
+    case "aliveplus":
+      increase("heartNumber");
+      break;
+    case "aliveminus":
+      decrease("heartNumber");
+      break;
+    case "voteplus":
+      increase("voteNumber");
+      break;
+    case "voteminus":
+      decrease("voteNumber");
+      break;
     case "toggleinfo":
       toggleInfo();
       break;

--- a/settings.js
+++ b/settings.js
@@ -7,6 +7,10 @@ let keybindings = {
   recall: "R",
   nextphase: ["N", "Enter"],
   previousphase: "P",
+  aliveplus: "Z",
+  aliveminus: "X",
+  voteplus: "C",
+  voteminus: "V",
   toggleinfo: "I",
   mute: "D",
   fullscreen: "F",
@@ -130,6 +134,14 @@ function loadSettings() {
   keybindings["previousphase"] = document.getElementById(
     "phaseprev"
   ).innerHTML = getSetting("settings_key_phaseprev", "P");
+  keybindings["aliveplus"] = document.getElementById("aliveplus").innerHTML =
+    getSetting("settings_key_aliveplus", "Z");
+  keybindings["aliveminus"] = document.getElementById("aliveminus").innerHTML =
+    getSetting("settings_key_aliveminus", "X");
+  keybindings["voteplus"] = document.getElementById("voteplus").innerHTML =
+    getSetting("settings_key_voteplus", "C");
+  keybindings["voteminus"] = document.getElementById("voteminus").innerHTML =
+    getSetting("settings_key_voteminus", "V");
   keybindings["reset"] = document.getElementById("timerreset").innerHTML =
     getSetting("settings_key_timerreset", "Backspace");
   keybindings["timer"] = document.getElementById("timeredit").innerHTML =
@@ -269,6 +281,22 @@ function saveSettings() {
     document.getElementById("phaseprev").innerHTML
   );
   setSetting(
+    "settings_key_aliveplus",
+    document.getElementById("aliveplus").innerHTML
+  );
+  setSetting(
+    "settings_key_aliveminus",
+    document.getElementById("aliveminus").innerHTML
+  );
+  setSetting(
+    "settings_key_voteplus",
+    document.getElementById("voteplus").innerHTML
+  );
+  setSetting(
+    "settings_key_voteminus",
+    document.getElementById("voteminus").innerHTML
+  );
+  setSetting(
     "settings_key_timerreset",
     document.getElementById("timerreset").innerHTML
   );
@@ -349,13 +377,30 @@ document
   });
 
 function settingsFeatureSpotifyTimer() {
-  let fsSpotify = document.querySelector('fieldset[name="spotify"]');
+  const fsSpotify = document.querySelector('fieldset[name="spotify"]');
   if (document.getElementById("featureSpotify").checked) {
     fsSpotify.classList.remove("noDisplay");
   } else {
     fsSpotify.classList.add("noDisplay");
   }
 }
+
+document
+  .getElementById("featureSpotify")
+  .addEventListener("change", settingsFeatureSpotifyTimer);
+
+function settingsFeatureRolesTrackers() {
+  const trackerkeys = document.getElementById('trackerkeys');
+  if (document.getElementById("featureRoles").checked) {
+    trackerkeys.classList.remove("noDisplay");
+  } else {
+    trackerkeys.classList.add("noDisplay");
+  }
+}
+
+document
+  .getElementById("featureRoles")
+  .addEventListener("change", settingsFeatureRolesTrackers);
 
 function settingsUpdateTimeValues() {
   const timerValues = calcTimerStartEndValues(
@@ -384,9 +429,6 @@ document
   .getElementById("playerCountInput")
   .addEventListener("change", settingsUpdateTimeValues);
 
-document
-  .getElementById("featureSpotify")
-  .addEventListener("change", settingsFeatureSpotifyTimer);
 function settingsUpdateTimer(save = false) {
   const totalNumbers = calcTimerStartEndValues(
     document.getElementById("playerCountInput").value


### PR DESCRIPTION
This implements keybindings to manipulate the dead/alive and vote counters. 

This implements #33 - but I decided to choose different default keybindings. Since everybody can change these by themself, I thought a good approach would be easy of typing.

- Z: Resurrect (increment heart)
- X: Kill (decrement heart)
- C: Regain Vote (increment vote)
- V: Ghostvote (decrement vote)

You also mentioned V, and X does fit somewhat with killing. Choosing neighbouring keys as default seemed fitting.

P.S.: I already have rebound resurrect to Y as I use a QWERTZ keyboard :'D Love that this is possible.