### PR TITLE
Autofocus character/traveller count in settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@
               max="15"
               step="1"
               value=""
+              autofocus
             />
             <label for="linkedTimerInput">Linked Timer</label>
             <input type="checkbox" id="linkedTimerInput" class="pregame" />

--- a/script.js
+++ b/script.js
@@ -191,6 +191,8 @@ document.querySelector("#settings").addEventListener("close", (e) => {
   if (document.querySelector("#settings").returnValue === "save") {
     if (!body.classList.contains("gameRunning")) {
       body.classList.add("gameRunning");
+      document.querySelector("#playerCountInput").autofocus = false;
+      document.querySelector("#travellerCountInput").autofocus = true;
     }
     saveSettings();
   }

--- a/style.css
+++ b/style.css
@@ -342,8 +342,8 @@ dialog .key.active {
   background-color: rgb(177, 36, 36);
 }
 
-#settings {
-  height: auto;
+.gameRunning #settings {
+  height: 90%;
 }
 
 #settings form {


### PR DESCRIPTION
Previously the info-icon had focus upon opening the settings dialogue, with this the focus is on the first to edit input (character count on startup; traveller count afterwards).