### PR TITLE
Fix restricted buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,12 +94,14 @@ function parseKeydown(e) {
       advanceTime();
       break;
     case "previousphase":
-      if (currentDay == 1 && isNight()) break;
-      if (!isEndOfDay()) {
-        currentDay = currentDay - 1;
+      if (!isTimerRunning) {
+        if (currentDay == 1 && isNight()) break;
+        if (!isEndOfDay()) {
+          currentDay = currentDay - 1;
+        }
+        phase++;
+        advanceTime();
       }
-      phase++;
-      advanceTime();
       break;
     case "aliveplus":
       increase("heartNumber");
@@ -402,32 +404,34 @@ function recall() {
 recallButton.addEventListener("click", recall);
 
 function advanceTime() {
-  phase = (phase + 1) % 3;
+  if (!isTimerRunning) {
+    phase = (phase + 1) % 3;
 
-  if (phase === NIGHT) {
-    currentDay = (currentDay % 15) + 1;
-  }
+    if (phase === NIGHT) {
+      currentDay = (currentDay % 15) + 1;
+    }
 
-  updateToggleButtonText();
-  updateBackground();
-  updateDefaultTime();
-  updateSpanText();
-  dayValue.textContent = currentDay;
+    updateToggleButtonText();
+    updateBackground();
+    updateDefaultTime();
+    updateSpanText();
+    dayValue.textContent = currentDay;
 
-  switch (phase) {
-    case DAY:
-      playDaySound();
-      break;
-    case ENDOFDAY:
-      playEndOfDaySound();
-      break;
-    case NIGHT:
-      playNightSound();
-      break;
-  }
+    switch (phase) {
+      case DAY:
+        playDaySound();
+        break;
+      case ENDOFDAY:
+        playEndOfDaySound();
+        break;
+      case NIGHT:
+        playNightSound();
+        break;
+    }
 
-  if (useSpotify()) {
-    spotifyVolume(volume[phase]);
+    if (useSpotify()) {
+      spotifyVolume(volume[phase]);
+    }
   }
 
   toggleTimeOfDayButton.blur();

--- a/style.css
+++ b/style.css
@@ -214,7 +214,7 @@ a:visited {
 .background-night #editTime,
 .background-night #incrementTime,
 .background-night #decrementTime {
-  color: rgb(111, 110, 110);
+  color: rgb(111, 110, 110) !important;
   cursor: default;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);


### PR DESCRIPTION
During a running countdown the restricted icons are currently (wrongly) formatted normally. This PR fixed that.
Also the [N]ext and [P]revious phase function did not check if the timer is running (and wherefore should do nothing). Also fixed.